### PR TITLE
More flexibility with Paginator.only

### DIFF
--- a/ButtonPaginator/__init__.py
+++ b/ButtonPaginator/__init__.py
@@ -1,3 +1,3 @@
 from .paginator import Paginator
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"


### PR DESCRIPTION
Allows `Paginator.only` to have one of the following types:
- `None`
- `discord.role.Role`
- `discord.abc.User`
- `List[Union[discord.role.Role, discord.abc.User]]`

Allows for more dynamic features in Paginators
